### PR TITLE
Fix traceback when no deliveryDate is found in shipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.2 - ???
+### Fixed
+- Traceback when no deliveryDate is found in shipment
+
 ## 1.0.1 - 2018-04-28
 ### Fixed
 - Export custom exception

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 (Unofficial) Python wrapper for the PostNL API (Dutch Postal Services), which can be used to track packages and letter deliveries. You can use your [jouw.postnl.nl](http://jouw.postnl.nl) credentials to use the API. 
 
 ## Quick test
+When installed:
+```python
+python -m postnl_api.test_postnl_api USERNAME PASSWORD
+```
+
+Or running directly:
 ```python
 test_postnl_api.py USERNAME PASSWORD
 ```

--- a/postnl_api/postnl_api.py
+++ b/postnl_api/postnl_api.py
@@ -236,7 +236,8 @@ class PostNL_API(object):
                 continue
 
             # Check if package has been delivered today
-            if shipment['status']['delivery']:
+            if shipment['status']['delivery'] and \
+               shipment['status']['delivery']['deliveryDate']:
                 delivery_date = datetime.strptime(
                     shipment['status']['delivery']['deliveryDate'][:19], "%Y-%m-%dT%H:%M:%S")
 


### PR DESCRIPTION
Fix traceback when no deliveryDate is found in shipment.

Found via HomeAssistant:
May 26 16:22:36 ... hass[22188]:   File "/.../homeassistant/lib/python3.5/site-packages/postnl_api/postnl_api.py", line 241, in get_relevant_shipments
May 26 16:22:36 campi hass[22188]:     shipment['status']['delivery']['deliveryDate'][:19], "%Y-%m-%dT%H:%M:%S")
